### PR TITLE
Move hooks in Data and add Interactors

### DIFF
--- a/src/features/business/data/graphql/hook/tests/useBusinessDetailsQuery.test.ts
+++ b/src/features/business/data/graphql/hook/tests/useBusinessDetailsQuery.test.ts
@@ -1,7 +1,7 @@
 import { ApolloError, useQuery } from '@apollo/client';
 import { renderHook } from '@testing-library/react-hooks';
-import { BusinessGraphQLModel } from '../../../data/graphql/model/BusinessGraphQLModel';
-import { Business } from '../../model/Business';
+import { BusinessGraphQLModel } from '../../model/BusinessGraphQLModel';
+import { Business } from '../../../../domain/model/Business';
 import { useBusinessDetailsQuery } from '../useBusinessDetailsQuery';
 
 jest.mock('@apollo/client', () => {

--- a/src/features/business/data/graphql/hook/tests/useBusinessListQuery.test.ts
+++ b/src/features/business/data/graphql/hook/tests/useBusinessListQuery.test.ts
@@ -1,7 +1,7 @@
 import { ApolloError, useQuery } from '@apollo/client';
 import { renderHook } from '@testing-library/react-hooks';
-import { BusinessGraphQLModel } from '../../../data/graphql/model/BusinessGraphQLModel';
-import { Business } from '../../model/Business';
+import { BusinessGraphQLModel } from '../../model/BusinessGraphQLModel';
+import { Business } from '../../../../domain/model/Business';
 import { useBusinessListQuery } from '../useBusinessListQuery';
 
 jest.mock('@apollo/client', () => {

--- a/src/features/business/data/graphql/hook/useBusinessDetailsQuery.ts
+++ b/src/features/business/data/graphql/hook/useBusinessDetailsQuery.ts
@@ -1,14 +1,14 @@
-import { ApolloError, useQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 import { useMemo } from 'react';
-import * as BusinessGraphQLMapper from '../../data/graphql/mapper/BusinessGraphQLMapper';
-import { BusinessDetailsGraphQLResponse } from '../../data/graphql/model/BusinessGraphQLModel';
-import { businessDetailsQuery } from '../../data/graphql/query/BusinessDetailsQuery';
-import { Business } from '../model/Business';
+import { Business } from '../../../domain/model/Business';
+import * as BusinessGraphQLMapper from '../mapper/BusinessGraphQLMapper';
+import { BusinessDetailsGraphQLResponse } from '../model/BusinessGraphQLModel';
+import { businessDetailsQuery } from '../query/BusinessDetailsQuery';
 
 export interface UseBusinessDetailsQueryHook {
   business: Business | undefined;
   loading: boolean;
-  error: ApolloError | undefined;
+  error: Error | undefined;
 }
 
 export const useBusinessDetailsQuery = (businessId: String): UseBusinessDetailsQueryHook => {

--- a/src/features/business/data/graphql/hook/useBusinessListQuery.ts
+++ b/src/features/business/data/graphql/hook/useBusinessListQuery.ts
@@ -1,14 +1,14 @@
-import { ApolloError, useQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 import { useMemo } from 'react';
-import * as BusinessGraphQLMapper from '../../data/graphql/mapper/BusinessGraphQLMapper';
-import { BusinessListGraphQLResponse } from '../../data/graphql/model/BusinessGraphQLModel';
-import { businessListQuery } from '../../data/graphql/query/BusinessListQuery';
-import { Business } from '../model/Business';
+import { Business } from '../../../domain/model/Business';
+import * as BusinessGraphQLMapper from '../mapper/BusinessGraphQLMapper';
+import { BusinessListGraphQLResponse } from '../model/BusinessGraphQLModel';
+import { businessListQuery } from '../query/BusinessListQuery';
 
 export interface UseBusinessListQueryHook {
   businesses: Business[];
   loading: boolean;
-  error: ApolloError | undefined;
+  error: Error | undefined;
 }
 
 export const useBusinessListQuery = (

--- a/src/features/business/domain/interactor/useBusinessDetailsInteractor.ts
+++ b/src/features/business/domain/interactor/useBusinessDetailsInteractor.ts
@@ -1,0 +1,12 @@
+import { useBusinessDetailsQuery } from '../../data/graphql/hook/useBusinessDetailsQuery';
+import { Business } from '../model/Business';
+
+export interface UseBusinessDetailsInteractorHook {
+  business: Business | undefined;
+  loading: boolean;
+  error: Error | undefined;
+}
+
+export const useBusinessDetailsInteractor = (businessId: String): UseBusinessDetailsInteractorHook => {
+  return useBusinessDetailsQuery(businessId);
+};

--- a/src/features/business/domain/interactor/useBusinessListInteractor.ts
+++ b/src/features/business/domain/interactor/useBusinessListInteractor.ts
@@ -1,0 +1,17 @@
+import { useBusinessListQuery } from '../../data/graphql/hook/useBusinessListQuery';
+import { Business } from '../model/Business';
+
+export interface UseBusinessListInteractorHook {
+  businesses: Business[];
+  loading: boolean;
+  error: Error | undefined;
+}
+
+export const useBusinessListInteractor = (
+  term: String,
+  location: String,
+  sortBy: String,
+  limit: number,
+): UseBusinessListInteractorHook => {
+  return useBusinessListQuery(term, location, sortBy, limit);
+};

--- a/src/features/business/presentation/businessdetails/tests/useBusinessDetails.test.ts
+++ b/src/features/business/presentation/businessdetails/tests/useBusinessDetails.test.ts
@@ -1,6 +1,6 @@
 import { ApolloError } from '@apollo/client';
 import { renderHook } from '@testing-library/react-hooks';
-import * as useBusinessDetailsQuery from '../../../domain/hook/useBusinessDetailsQuery';
+import * as useBusinessDetailsQuery from '../../../data/graphql/hook/useBusinessDetailsQuery';
 import { Business } from '../../../domain/model/Business';
 import { BusinessDetailsUiModel } from '../BusinessDetailsUiModel';
 import { useBusinessDetails } from '../useBusinessDetails';

--- a/src/features/business/presentation/businessdetails/useBusinessDetails.ts
+++ b/src/features/business/presentation/businessdetails/useBusinessDetails.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import { useBusinessDetailsQuery } from '../../domain/hook/useBusinessDetailsQuery';
+import { useBusinessDetailsInteractor } from '../../domain/interactor/useBusinessDetailsInteractor';
 import { Business } from '../../domain/model/Business';
 import * as BusinessDetailsMapper from './BusinessDetailsMapper';
 import { BusinessDetailsUiModel } from './BusinessDetailsUiModel';
@@ -57,7 +57,7 @@ const reducer = (state: State, action: Action): State => {
 
 export const useBusinessDetails = (businessId: String): UseBusinessDetailsHook => {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const { business, loading, error } = useBusinessDetailsQuery(businessId);
+  const { business, loading, error } = useBusinessDetailsInteractor(businessId);
 
   useEffect(() => {
     if (loading) {

--- a/src/features/business/presentation/businesslist/tests/useBusinessList.test.ts
+++ b/src/features/business/presentation/businesslist/tests/useBusinessList.test.ts
@@ -1,6 +1,6 @@
 import { ApolloError } from '@apollo/client';
 import { renderHook } from '@testing-library/react-hooks';
-import * as useBusinessListQuery from '../../../domain/hook/useBusinessListQuery';
+import * as useBusinessListQuery from '../../../data/graphql/hook/useBusinessListQuery';
 import { Business } from '../../../domain/model/Business';
 import { BusinessListUiModel } from '../BusinessListUiModel';
 import { useBusinessList } from '../useBusinessList';

--- a/src/features/business/presentation/businesslist/useBusinessList.ts
+++ b/src/features/business/presentation/businesslist/useBusinessList.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import { useBusinessListQuery } from '../../domain/hook/useBusinessListQuery';
+import { useBusinessListInteractor } from '../../domain/interactor/useBusinessListInteractor';
 import { Business } from '../../domain/model/Business';
 import * as BusinessListMapper from './BusinessListMapper';
 import { BusinessListUiModel } from './BusinessListUiModel';
@@ -63,7 +63,7 @@ export const useBusinessList = (
   limit: number,
 ): UseBusinessListHook => {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const { businesses, loading, error } = useBusinessListQuery(term, location, sortBy, limit);
+  const { businesses, loading, error } = useBusinessListInteractor(term, location, sortBy, limit);
 
   useEffect(() => {
     if (loading) {


### PR DESCRIPTION
Resolves #23

Moved hooks in the data layer and added Interactors in between.

-----
As I said in the issue description, I am not sure if this is the best way to layer all this. Maybe I am trying too much to push for Clean Architecture.

Since [hooks can't be used inside classes](https://reactjs.org/docs/hooks-faq.html#should-i-use-hooks-classes-or-a-mix-of-both), I don't see how I could easily swap a GraphQL implementation for a REST one using DI like I did with Flutter and Android native. If this type of change needs to be performed, the presentation layer would still be untouched, but interactors would have to change.

It might be better to be using the apollo hooks directly in the presentation layer, as suggested in the Apollo documentation, but it feels wrong regarding separation of concerns.